### PR TITLE
"IsUndefined()" replaced by "== js.Undefined", as in gopherjs/js/js.go

### DIFF
--- a/jquery.go
+++ b/jquery.go
@@ -317,7 +317,7 @@ func (j JQuery) RemoveProp(property string) JQuery {
 
 func (j JQuery) Attr(property string) string {
 	attr := j.o.Call("attr", property)
-	if attr.IsUndefined() {
+	if attr == js.Undefined {
 		return ""
 	}
 	return attr.Str()
@@ -546,7 +546,7 @@ func (j JQuery) SetData(key string, value interface{}) JQuery {
 
 func (j JQuery) Data(key string) interface{} {
 	result := j.o.Call("data", key)
-	if result.IsUndefined() {
+	if result == js.Undefined {
 		return nil
 	}
 	return result.Interface()

--- a/test/test/index.go
+++ b/test/test/index.go
@@ -494,7 +494,7 @@ func main() {
 	QUnit.Test("On,One,Off,Trigger", func(assert QUnit.QUnitAssert) {
 
 		fn := func(ev jquery.Event) {
-			assert.Ok(!ev.Data.IsUndefined(), "on() with data, check passed data exists")
+			assert.Ok(!ev.Data == js.Undefined, "on() with data, check passed data exists")
 			assert.Equal(ev.Data.Get("foo"), "bar", "on() with data, Check value of passed data")
 		}
 


### PR DESCRIPTION
The `js.Object.IsUndefined()` function has been deprecated 2 days ago in the `gopherjs/js` package, in favor of a comparison to `js.Undefined`.

This `gopherjs/jquery`package is broken because of that, giving the following errors:
```
github.com/gopherjs/jquery/jquery.go:320:5: invalid operation: attr (variable of type github.com/gopherjs/gopherjs/js.Object) has no field or method IsUndefined
github.com/gopherjs/jquery/jquery.go:549:5: invalid operation: result (variable of type github.com/gopherjs/gopherjs/js.Object) has no field or method IsUndefined
```