### PR TITLE
Change import statement back to gopherjs/jquery.

### DIFF
--- a/test/test/index.go
+++ b/test/test/index.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/albrow/jquery"
 	"github.com/gopherjs/gopherjs/js"
+	"github.com/gopherjs/jquery"
 	QUnit "github.com/rusco/qunit"
 	"strconv"
 	"strings"


### PR DESCRIPTION
I needed to change it to my fork at albrow/jquery temporarily
in order to get the test file to build so I could test my changes.
Since PR #5 was merged, we can build with gopherjs/jquery now.

Sorry about this. I mentioned this caveat in PR #5 but it was easy to gloss
over. Anyways it's a quick fix and I'll keep my branch up so it won't even break
anything as it is now.