### PR TITLE
Add Call() wrapper.

### DIFF
--- a/jquery.go
+++ b/jquery.go
@@ -208,6 +208,10 @@ func (j JQuery) Each(fn func(int, interface{})) JQuery {
 	return j
 }
 
+func (j JQuery) Call(name string, args ...interface{}) JQuery {
+	return NewJQuery( j.o.Call(name, args...) )
+}
+
 func (j JQuery) Underlying() *js.Object {
 	return j.o
 }


### PR DESCRIPTION
This patch adds a `Call()` method to the jQuery package. While the existing package does a good job (to my knowledge) of exposing all of the standard jQuery methods, it naturally doesn't expose methods added by jQuery plugins or extensions.

With the use of jQuery Mobile (and likely many other jQuery plugins), it's quite common to need to call methods which are members of the global jQuery object.  Without this patch, this is done with code such as:

    jquery.NewJQuery("body>[data-role='panel']" ).Underlying().Call("panel").Call("enhanceWithin")

After this patch, this is shortened to:

    jquery.NewJQuery("body>[data-role='panel']" ).Call("panel").Call("enhanceWithin")

In the case that the result is needed as a jQuery object rather than a standard JS object, the convenience is amplified:

    foo = jquery.NewJQuery("#someid").Underlying().Call("returnFooElement")
    fooJQ = jquery.NewJQuery( foo )
    fooJQ.On(....)

becomes:

    jquery.NewJQuery("#someid").Call("returnFooElement").On(...)
