### PR TITLE
Fix #19 syntax error

### DIFF
--- a/jquery.go
+++ b/jquery.go
@@ -211,7 +211,7 @@ func (j JQuery) Each(fn func(int, interface{})) JQuery {
 }
 
 func (j JQuery) Call(name string, args ...interface{}) JQuery {
-	return NewJQuery( j.o.Call(name, args...) )
+	return NewJQuery(j.o.Call(name, args...))
 }
 
 func (j JQuery) Underlying() *js.Object {
@@ -502,7 +502,7 @@ func (j JQuery) SetWidth(i interface{}) JQuery {
 	return j
 }
 
-func (j JQuery) Index(i interface{}...) int {
+func (j JQuery) Index(i interface{}) int {
 	return j.o.Call("index", i).Int()
 }
 


### PR DESCRIPTION
#19 introduced a syntax error: `github.com/gopherjs/jquery/jquery.go:505:36: syntax error: unexpected ..., expecting comma or )`.

I suppose @kelwang wanted to write `...interface{}` instead of `interface{}...`.
But even the variadic is useless according to the jQuery API, so let's use a simple `interface{}`.

---

Please consider adding a CI tool someday.
Or just run `golint` + `gofmt` before creating/merging a PR at least.